### PR TITLE
Refactor the countdown to remove activesupport

### DIFF
--- a/lib/21-day-challenge-countdown.rb
+++ b/lib/21-day-challenge-countdown.rb
@@ -1,7 +1,4 @@
-# Well I need a bit of rails (for convenience) here!
-require 'active_support'
-require 'active_support/time_with_zone'
-require 'active_support/core_ext/time/zones'
+require 'time'
 
 module TwentyOneDayChallenge
   class Countdown
@@ -9,21 +6,24 @@ module TwentyOneDayChallenge
     attr_reader :current_day
 
     def initialize
-      Time.zone = 'UTC'
-      start = ActiveSupport::TimeZone.new('Mountain Time (US & Canada)')
-        .parse('13/04/2015 12:00').to_datetime
-      now = Time.zone.now.to_datetime
-      elapsed = (now - start)
-      @current_day = (elapsed).ceil
-      next_deadline = start + @current_day
-      left_today = next_deadline.to_time - now.to_time
-      @time_left = Time.zone.at(left_today)
+      start_time = Time.parse('2015-05-04 12:00:00 -0600')
+      now = Time.now
+
+      elapsed = (now - start_time)
+      @current_day = (elapsed / 60/ 60 / 24).ceil
+      current_day_in_seconds = @current_day * 60 * 60 * 24
+
+      next_deadline = start_time + current_day_in_seconds - 1
+      left_today = next_deadline - now
+      @time_left = Time.at(left_today).gmtime
       # left_string = @time_left.strftime("%H:%M:%S")
     end
 
     def deadline
-      "Today is day #{current_day}. You have #{time_left.strftime('%H:%M:%S')
-                                             } left to send your pull request."
+      format_string = "Today is day %s. You have %s hours, %s minutes "\
+                      "and %s seconds left to send your pull request."
+      format_string % [current_day, time_left.strftime('%H'),
+                       time_left.strftime('%M'), time_left.strftime('%S')]
     end
   end
 end

--- a/lib/21-day-challenge-countdown.rb
+++ b/lib/21-day-challenge-countdown.rb
@@ -6,7 +6,7 @@ module TwentyOneDayChallenge
     attr_reader :current_day
 
     def initialize
-      start_time = Time.parse('2015-05-04 12:00:00 -0600')
+      start_time = Time.parse('2015-06-01 12:00:00 -0600')
       now = Time.now
 
       elapsed = (now - start_time)


### PR DESCRIPTION
Just wanted to check if it was possible to get all the functionality out of the gem without the activesupport requirements. It's perfectly functional and returns everything as detailed in the gem's README.
Maybe consider a pull request? :+1: 
